### PR TITLE
[Fix] Create provision dependencies for waiting some time for the container registry DNS

### DIFF
--- a/infra/core/host/container-apps.bicep
+++ b/infra/core/host/container-apps.bicep
@@ -39,7 +39,7 @@ module containerRegistry 'container-registry.bicep' = {
 
 // Wait for the registry to be ready before continuing
 // DNS propagation can take up to 60 sec
-// see: https://learn.microsoft.com/en-us/azure/dns/dns-faq#how-long-does-it-take-for-dns-changes-to-take-effect-
+// see: https://learn.microsoft.com/azure/dns/dns-faq#how-long-does-it-take-for-dns-changes-to-take-effect-
 resource waitForRegistry 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: 'wait-for-registry-app-container-registry'
   location: location

--- a/infra/core/host/container-apps.bicep
+++ b/infra/core/host/container-apps.bicep
@@ -13,6 +13,9 @@ param daprEnabled bool = false
 
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'
+  // Container Envieronment does depend directly on the registry, but we want to wait for the registry to be ready 
+  // The time for creating the container environment is used to wait for the container registry to be ready (DNS propagation)
+  dependsOn: [containerRegistry]
   params: {
     name: containerAppsEnvironmentName
     location: location
@@ -31,6 +34,28 @@ module containerRegistry 'container-registry.bicep' = {
     location: location
     adminUserEnabled: containerRegistryAdminUserEnabled
     tags: tags
+  }
+}
+
+// Wait for the registry to be ready before continuing
+// DNS propagation can take up to 60 sec
+// see: https://learn.microsoft.com/en-us/azure/dns/dns-faq#how-long-does-it-take-for-dns-changes-to-take-effect-
+resource waitForRegistry 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'wait-for-registry-app-container-registry'
+  location: location
+  kind: 'AzureCLI'
+  dependsOn: [
+    containerAppsEnvironment
+  ]
+  properties: {
+    azCliVersion: '2.61.0'
+    retentionInterval: 'PT1H' // Retain the script resource for 1 hour after it ends running
+    timeout: 'PT5M' // Five minutes
+    cleanupPreference: 'OnSuccess'
+    scriptContent: '''
+      # setting up deployment script takes about 1 minute, which is the max time we need to wait for DNS propagation
+      echo "Waited at least 60 seconds for DNS propagation. If container registry is not found, an error will be returned."
+    '''
   }
 }
 


### PR DESCRIPTION
When the Container Registry and Container Environment are created:

![image](https://github.com/user-attachments/assets/d9a1a420-e30a-40c3-b78f-2c1e4b0fb000)

They both run in parallel, as there are no dependencies between them.  

Then, during ACA creation:

![image](https://github.com/user-attachments/assets/c74f6a03-807a-43e1-b558-16f97d0e983c)

If the Container Registry DNS is not yet propagated due to Azure DNS (see: https://learn.microsoft.com/azure/dns/dns-faq#how-long-does-it-take-for-dns-changes-to-take-effect-) the deployment fails with a 404 error.

This PR creates a dependency for the Container Environment to wait until the registry is created. This bring some time (while the container environment is created) for DNS propagation.  
It also adds a deployment script after the Container Environment, which takes about 1 min to be set up and started.

This strategy ensures enough time before trying to create the Container App to avoid getting a 404 -> registry not found