### PR TITLE
Update requirements.txt to skip uvloop on Windows machines 

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -161,7 +161,7 @@ urllib3==2.2.3
     # via requests
 uvicorn[standard]==0.31.1
     # via quartapp (pyproject.toml)
-uvloop==0.20.0
+uvloop==0.20.0; platform_system != "Windows"
     # via uvicorn
 watchfiles==0.24.0
     # via uvicorn


### PR DESCRIPTION
Skips installing uvloop on Windows machines.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
*uvloop doesn't support Windows* 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
`pip install -r src/requirements.txt` on a windows machine


* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
